### PR TITLE
add quick enabled flag and generate quick connect URL

### DIFF
--- a/internal/models/instance.go
+++ b/internal/models/instance.go
@@ -18,11 +18,13 @@ type InstanceModel struct {
 }
 
 type InstanceSpec struct {
-	InstanceGroup     types.String   `tfsdk:"instance_group"`
-	InstanceType      types.String   `tfsdk:"instance_type"`
-	MachineImage      types.String   `tfsdk:"machine_image"`
-	SSHPublicKeyNames []types.String `tfsdk:"ssh_public_key_names"`
-	UserData          types.String   `tfsdk:"user_data"`
+	InstanceGroup       types.String   `tfsdk:"instance_group"`
+	InstanceType        types.String   `tfsdk:"instance_type"`
+	MachineImage        types.String   `tfsdk:"machine_image"`
+	SSHPublicKeyNames   []types.String `tfsdk:"ssh_public_key_names"`
+	UserData            types.String   `tfsdk:"user_data"`
+	QuickConnectEnabled types.String   `tfsdk:"quick_connect_enabled"`
+	QuickConnectUrl     types.String   `tfsdk:"quick_connect_url"`
 }
 
 type NetworkInterfaceSpec struct {

--- a/internal/provider/instance_data_source.go
+++ b/internal/provider/instance_data_source.go
@@ -93,6 +93,9 @@ func (d *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 								"user_data": schema.StringAttribute{
 									Optional: true,
 								},
+								"quick_connect_enabled": schema.StringAttribute{
+									Optional: true,
+								},
 							},
 						},
 						"interfaces": schema.ListNestedAttribute{

--- a/internal/provider/instance_resource.go
+++ b/internal/provider/instance_resource.go
@@ -113,6 +113,7 @@ func (r *computeInstanceResource) Schema(_ context.Context, _ resource.SchemaReq
 					},
 					"quick_connect_url": schema.StringAttribute{
 						Computed: true,
+						Optional: true,
 					},
 				},
 			},

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,5 +1,14 @@
 package provider
 
+import "strings"
+
 func remove(slice []interface{}, s int) []interface{} {
 	return append(slice[:s], slice[s+1:]...)
+}
+
+func capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/pkg/itacservices/instances.go
+++ b/pkg/itacservices/instances.go
@@ -42,9 +42,11 @@ type Instance struct {
 			Name string `json:"name"`
 			VNet string `json:"vnet"`
 		} `json:"interfaces"`
-		MachineImage      string   `json:"machineImage"`
-		SshPublicKeyNames []string `json:"sshPublicKeyNames"`
-		UserData          string   `json:"userData,omitempty"`
+		MachineImage        string   `json:"machineImage"`
+		SshPublicKeyNames   []string `json:"sshPublicKeyNames"`
+		UserData            string   `json:"userData,omitempty"`
+		QuickConnectEnabled string   `json:"quickConnectEnabled,omitempty"`
+		QuickConnectUrl     string   `json:"quickConnectUrl,omitempty"`
 	} `json:"spec"`
 	Status struct {
 		Interfaces []struct {
@@ -79,9 +81,10 @@ type InstanceCreateRequest struct {
 			Name string `json:"name"`
 			VNet string `json:"vNet"`
 		} `json:"interfaces"`
-		MachineImage      string   `json:"machineImage"`
-		SshPublicKeyNames []string `json:"sshPublicKeyNames"`
-		UserData          string   `json:"userData,omitempty"`
+		MachineImage        string   `json:"machineImage"`
+		SshPublicKeyNames   []string `json:"sshPublicKeyNames"`
+		UserData            string   `json:"userData,omitempty"`
+		QuickConnectEnabled string   `json:"quickConnectEnabled,omitempty"`
 	} `json:"spec"`
 }
 


### PR DESCRIPTION
##Issue##: https://github.com/intel/terraform-provider-intelcloud/issues/11
---
**JIRA**:  https://jira.devtools.intel.com/browse/IDCCOMP-4180 
---
**Changes**
- Add new flag for enabling quick connect for instances
- Generate and display URL for quick connect as part of terraform output
---
**Testing evidence**
URL created after instance creation
![image](https://github.com/user-attachments/assets/4f832c22-1bd0-4668-bacb-ac322f480db1)


Verification that URL generated is the correct one
![image](https://github.com/user-attachments/assets/a1217126-6d70-4a40-bd89-532cfe6796d1)


