### PR TITLE
add import methods for iks cluster and iks loadbalancer

### DIFF
--- a/internal/provider/iks_cluster_resource.go
+++ b/internal/provider/iks_cluster_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -17,8 +18,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &iksClusterResource{}
-	_ resource.ResourceWithConfigure = &iksClusterResource{}
+	_ resource.Resource                = &iksClusterResource{}
+	_ resource.ResourceWithConfigure   = &iksClusterResource{}
+	_ resource.ResourceWithImportState = &iksClusterResource{}
 )
 
 // orderKubernetesModel maps the resource schema data.
@@ -372,6 +374,11 @@ func (r *iksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	tflog.Info(ctx, "no change detected change in cluster spec, skipping update")
+}
+
+func (r *iksClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/iks_load_balancer_resource.go
+++ b/internal/provider/iks_load_balancer_resource.go
@@ -7,6 +7,7 @@ import (
 	"terraform-provider-intelcloud/internal/models"
 	"terraform-provider-intelcloud/pkg/itacservices"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -14,8 +15,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &iksLBResource{}
-	_ resource.ResourceWithConfigure = &iksLBResource{}
+	_ resource.Resource                = &iksLBResource{}
+	_ resource.ResourceWithConfigure   = &iksLBResource{}
+	_ resource.ResourceWithImportState = &iksLBResource{}
 )
 
 // orderIKSNodeGroupModel maps the resource schema data.
@@ -179,4 +181,9 @@ func (r *iksLBResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *iksLBResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func (r *iksLBResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
### JIRA
---
https://jira.devtools.intel.com/browse/IDCCOMP-4318

### Issue: #28 
---

### Change
---
- Add import implementation for the following resources 
- IKS cluster
- IKS loadbalancer
- More details in the JIRA ticket above

### Testing evidence
* Successful Import of IKS cluster resource using `terraform import ...` command
![image](https://github.com/user-attachments/assets/6fbc941c-a86f-470f-a79d-3fd824b29805)


* Successful `terraform show` command after import
![image](https://github.com/user-attachments/assets/d830733e-35e6-4a62-8b64-cb3c309c56c1)

* Successful `terraform apply` command to update imported IKS cluster resource (upgrading the cluster's k8s version from 1.30 --> 1.31)
 ![image](https://github.com/user-attachments/assets/c5b664d0-b71a-4659-ad29-62becfd2b165)

