### PR TITLE
fix vnet creation when vnet is not present, add region 5

### DIFF
--- a/internal/models/instance.go
+++ b/internal/models/instance.go
@@ -28,8 +28,8 @@ type InstanceSpec struct {
 }
 
 type NetworkInterfaceSpec struct {
-	Name types.String `tfsdk:"name"`
-	VNet types.String `tfsdk:"vnet"`
+	AvailabilityZoneName     types.String `tfsdk:"availabilityzonename"`
+	NetworkInterfaceVnetName types.String `tfsdk:"networkinterfacevnetname"`
 }
 
 type NetworkInterface struct {

--- a/internal/models/kubernetes.go
+++ b/internal/models/kubernetes.go
@@ -65,15 +65,15 @@ func (m ClusterNetwork) AttributeTypes() map[string]attr.Type {
 }
 
 type NodeGroup struct {
-	ID                types.String           `tfsdk:"id"`
-	Count             types.Int64            `tfsdk:"ng_count"`
-	Name              types.String           `tfsdk:"name"`
-	InstanceType      types.String           `tfsdk:"instance_type"`
-	IMIId             types.String           `tfsdk:"imiid"`
-	State             types.String           `tfsdk:"state"`
-	UserDataURL       types.String           `tfsdk:"userdata_url"`
-	SSHPublicKeyNames []types.String         `tfsdk:"ssh_public_key_names"`
-	Interfaces        []NetworkInterfaceSpec `tfsdk:"interfaces"`
+	ID                types.String   `tfsdk:"id"`
+	Count             types.Int64    `tfsdk:"ng_count"`
+	Name              types.String   `tfsdk:"name"`
+	InstanceType      types.String   `tfsdk:"instance_type"`
+	IMIId             types.String   `tfsdk:"imiid"`
+	State             types.String   `tfsdk:"state"`
+	UserDataURL       types.String   `tfsdk:"userdata_url"`
+	SSHPublicKeyNames []types.String `tfsdk:"ssh_public_key_names"`
+	Interfaces        types.List     `tfsdk:"vnets"`
 }
 
 var NodeGroupAttributes = map[string]attr.Type{
@@ -84,6 +84,11 @@ var NodeGroupAttributes = map[string]attr.Type{
 	"imiid":         types.StringType,
 	"state":         types.StringType,
 	"userdata_url":  types.StringType,
+}
+
+var VnetAttributes = map[string]attr.Type{
+	"availabilityzonename":     types.StringType,
+	"networkinterfacevnetname": types.StringType,
 }
 
 type IKSLoadBalancer struct {

--- a/internal/provider/instance_resource.go
+++ b/internal/provider/instance_resource.go
@@ -244,7 +244,7 @@ func (r *computeInstanceResource) Create(ctx context.Context, req resource.Creat
 			}{
 				{
 					Name: "eth0",
-					VNet: fmt.Sprintf("%sa-default", *r.client.Region),
+					VNet: vnetResp.Metadata.Name,
 				},
 			},
 			InstanceType:        plan.Spec.InstanceType.ValueString(),

--- a/internal/provider/instance_resource.go
+++ b/internal/provider/instance_resource.go
@@ -203,7 +203,7 @@ func (r *computeInstanceResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	tflog.Info(ctx, "making a call to IDC Service to createVnetIfNotExist")
-	vnetResp, err := r.client.CreateVNetIfNotFound(ctx)
+	vnetResp, err := r.client.CreateVNetIfNotFound(ctx, *r.client.Region)
 	if err != nil || vnetResp == nil {
 		resp.Diagnostics.AddError(
 			"Error creating order",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -253,6 +253,8 @@ func discoverITACServiceEndpoint(region string) (string, string) {
 		return "https://client-token.api.idcservice.net", "https://us-region-3-sdk-api.cloud.intel.com"
 	case "us-region-4":
 		return "https://client-token.api.idcservice.net", "https://us-region-4-sdk-api.cloud.intel.com"
+	case "us-region-5":
+		return "https://client-token.api.idcservice.net", "https://us-region-5-sdk-api.cloud.intel.com"
 	default:
 		return "", ""
 	}

--- a/pkg/itacservices/common/utils.go
+++ b/pkg/itacservices/common/utils.go
@@ -50,3 +50,11 @@ func mapAPIErrorMessage(retval []byte) error {
 	}
 	return fmt.Errorf("%v", apiError.Message)
 }
+
+func GetAvailabiltyZoneAndVnet(region string) (string, string) {
+	availabilityZone := fmt.Sprintf("%sa", region)
+	vnetName := fmt.Sprintf("%s-default", availabilityZone)
+
+	return availabilityZone, vnetName
+
+}

--- a/pkg/itacservices/instances.go
+++ b/pkg/itacservices/instances.go
@@ -107,13 +107,14 @@ type VNet struct {
 
 type VNetCreateRequest struct {
 	Metadata struct {
-		Name string `json:"name"`
+		Name         string `json:"name"`
+		CloudAccount string `json:"cloudAccount"`
 	} `json:"metadata"`
 	Spec struct {
 		AvailabilityZone string `json:"availabilityZone"`
 		Region           string `json:"region"`
-		PrefixLength     int64  `json:"prefixLength"`
-	}
+		PrefixLength     int32  `json:"prefixLength"`
+	} `json:"spec"`
 }
 
 func (client *IDCServicesClient) GetInstances(ctx context.Context) (*Instances, error) {
@@ -278,7 +279,7 @@ func (client *IDCServicesClient) DeleteInstanceByResourceId(ctx context.Context,
 	return nil
 }
 
-func (client *IDCServicesClient) CreateVNetIfNotFound(ctx context.Context) (*VNet, error) {
+func (client *IDCServicesClient) CreateVNetIfNotFound(ctx context.Context, region string) (*VNet, error) {
 
 	params := struct {
 		Host         string
@@ -314,19 +315,22 @@ func (client *IDCServicesClient) CreateVNetIfNotFound(ctx context.Context) (*VNe
 
 	tflog.Debug(ctx, "vnets not found, creating a new")
 
+	availabilityZone, vnetName := common.GetAvailabiltyZoneAndVnet(region)
 	inArgs := VNetCreateRequest{
 		Metadata: struct {
-			Name string "json:\"name\""
+			Name         string "json:\"name\""
+			CloudAccount string "json:\"cloudAccount\""
 		}{
-			Name: "us-staging-1a-default",
+			Name:         vnetName,
+			CloudAccount: *client.Cloudaccount,
 		},
 		Spec: struct {
 			AvailabilityZone string "json:\"availabilityZone\""
 			Region           string "json:\"region\""
-			PrefixLength     int64  "json:\"prefixLength\""
+			PrefixLength     int32  "json:\"prefixLength\""
 		}{
-			AvailabilityZone: "us-staging-1a",
-			Region:           "us-staging-1",
+			AvailabilityZone: availabilityZone,
+			Region:           region,
 			PrefixLength:     24,
 		},
 	}
@@ -345,7 +349,7 @@ func (client *IDCServicesClient) CreateVNetIfNotFound(ctx context.Context) (*VNe
 	retcode, retval, err = common.MakePOSTAPICall(ctx, parsedURL, *client.Apitoken, payload)
 
 	if err != nil || retcode != http.StatusOK {
-		return nil, fmt.Errorf("error reading vnet create response")
+		return nil, fmt.Errorf("error reading vnet create response: %v", err)
 	}
 
 	vnet := VNet{}

--- a/pkg/itacservices/instances.go
+++ b/pkg/itacservices/instances.go
@@ -310,6 +310,7 @@ func (client *IDCServicesClient) CreateVNetIfNotFound(ctx context.Context, regio
 	tflog.Debug(ctx, "vnets get api response", map[string]any{"retcode": retcode, "retval": vnets})
 
 	if len(vnets.Vnets) > 0 {
+		tflog.Debug(ctx, "existing vnets found")
 		return &(vnets.Vnets[0]), nil
 	}
 

--- a/pkg/itacservices/kubernetes.go
+++ b/pkg/itacservices/kubernetes.go
@@ -79,6 +79,7 @@ type NodeGroup struct {
 	NetworkInterfaceName string `json:"networkinterfacename"`
 	IMIID                string `json:"imiid"`
 	UserDataURL          string `json:"userdataurl"`
+	Interfaces           []Vnet `json:"vnets"`
 }
 
 type SKey struct {
@@ -98,10 +99,12 @@ type IKSNodeGroupCreateRequest struct {
 	InstanceTypeId string `json:"instancetypeid"`
 	SSHKeyNames    []SKey `json:"sshkeyname"`
 	UserDataURL    string `json:"userdataurl"`
-	Interfaces     []struct {
-		AvailabilityZone string `json:"availabilityzonename"`
-		VNet             string `json:"networkinterfacevnetname"`
-	} `json:"vnets"`
+	Vnets          []Vnet `json:"vnets"`
+}
+
+type Vnet struct {
+	AvailabilityZoneName     string `json:"availabilityzonename"`
+	NetworkInterfaceVnetName string `json:"networkinterfacevnetname"`
 }
 
 type IKSCreateRequest struct {


### PR DESCRIPTION
### JIRA
https://jira.devtools.intel.com/browse/IDCCOMP-4573
---
### Issue #31 
---
### Changes
- This fixes the existing `CreateVNetIfNotFound` error to create the Vnet in the correct region, availability zone, and with the correct name.
- With this fix if Vnet does exists one will be created but if one exists, vnet creation details will be fetched automatically and used when provisioning
- This way provision of instance the first time in a region works correctly
- This way provision of IKS clusters with node groups the first time in a region works correctly
- This also fixes errors with nodegroup provisioning caused due to stale models (since ITAC API responses) seem to have changed
- Support for `us-region-5`
---
### Testing evidence
*Deploying instance for the first time in a region*
![image](https://github.com/user-attachments/assets/dd4ee41a-7ebb-4be3-b010-543368dc5971)

*Deploying IKS clusters with storage + nodegroups*
![image](https://github.com/user-attachments/assets/068cb06b-6b97-468c-8288-4aa42b15a7c8)